### PR TITLE
Adding support for QtCreator to show header files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,3 +184,6 @@ add_custom_command(TARGET ${TARGET}.elf POST_BUILD COMMAND ${CMAKE_SIZE} ${TARGE
 #other
 ADD_CUSTOM_TARGET(${TARGET}.hex DEPENDS ${TARGET}.elf COMMAND ${CMAKE_OBJCOPY} -Oihex ${TARGET} ${TARGET}.hex)
 ADD_CUSTOM_TARGET(${TARGET}.bin DEPENDS ${TARGET}.elf COMMAND ${CMAKE_OBJCOPY} -Obinary ${TARGET} ${TARGET}.bin)
+
+FILE(GLOB_RECURSE LibFiles "*.h")
+add_custom_target(headers SOURCES ${LibFiles})


### PR DESCRIPTION
QtCreator does not show .h header files by default so it is required
to add a custom target for them in the cmakelist.
These two lines will do the trick.